### PR TITLE
Update README to correct CSV file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ usually come from the practice management software, or photo management
 software.
 
 The easiest way to feed this information to `dicom4ortho`'s CLI is using a
-CSV file. You can find an example CSV file [here](resources/example/input_from.csv)
+CSV file. You can find an example CSV file [here](resources/original-images/input_from.csv).
 
 Once installed, if necessary, start the virtual environment:
 


### PR DESCRIPTION
**Problem**
When I was reading the `README.md` I saw a csv referenced, clicked on it, and got a 404.

**Solution**
Replaced the URL with the nearest CSV file I could find to what the README was previously pointing to. I'm not sure if it's the actual example CSV.